### PR TITLE
Fix language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.aii linguist-language=Assembly
 *.r linguist-language=Rez
 *.p linguist-language=Pascal
+Misc/VM\ Release\ Note\ 1.2 linguist-language=text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.a linguist-language=Assembly
+*.aii linguist-language=Assembly
+*.r linguist-language=Rez
+*.p linguist-language=Pascal


### PR DESCRIPTION
GitHub Linguist still requires a bit of help to categorize certain languages properly; this PR adds a `.gitattributes` file to do so.